### PR TITLE
Semantic update for LOAD_GENERATOR_NODES.

### DIFF
--- a/alderaan/property_files/http.properties
+++ b/alderaan/property_files/http.properties
@@ -31,7 +31,7 @@ CONTAINERIZED=false
 # HTTP-test specifics
 # A synchronization endpoint listening at :9090 by default.
 GUN=
-# Comma separated load-generator nodes (use "oc get nodes" node names).
+# Load-generator nodes described by an extended regular expression (use "oc get nodes" node names).
 LOAD_GENERATOR_NODES=
 # Number of projects to create for each type of application (4 types currently).
 CL_PROJECTS=10


### PR DESCRIPTION
Load generator nodes are now described by a regular expression, rather than comma-separated list.

@chaitanyaenr PTAL